### PR TITLE
Update dependencies (#1255)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
     - id: black
       name: Blacken

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -3,5 +3,5 @@ aiida-core==2.0.1;python_version>='3.8'
 ase==3.22.1
 jarvis-tools==2022.5.20
 numpy==1.21.5;python_version<'3.8'
-numpy==1.22.4;python_version>='3.8'
+numpy==1.23.0;python_version>='3.8'
 pymatgen==2022.0.16

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,5 +3,5 @@ markupsafe==2.0.1 # Can be removed once aiida supports Jinja2>=3, see pallets/ma
 mike==1.1.2
 mkdocs==1.3.0
 mkdocs-awesome-pages-plugin==2.7.0
-mkdocs-material==8.3.6
+mkdocs-material==8.3.8
 mkdocstrings[python]==0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pymongo==4.1.1
 pyyaml==5.4
 requests==2.28.0
 typing-extensions==4.0.0;python_version<'3.8'
-uvicorn==0.17.6
+uvicorn==0.18.1

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(module_dir.joinpath("optimade/__init__.py")) as version_file:
 elastic_deps = ["elasticsearch-dsl~=7.4,<8.0"]
 mongo_deps = ["pymongo>=3.12.1,<5", "mongomock~=4.0"]
 server_deps = [
-    "uvicorn~=0.17",
+    "uvicorn~=0.18",
     "pyyaml>=5.4,<7",  # Keep at pyyaml 5.4 for aiida-core support
 ] + mongo_deps
 


### PR DESCRIPTION
Update dependencies:

* Bump mkdocs-material from 8.3.6 to 8.3.8 (#1251)
* Bump uvicorn from 0.17.6 to 0.18.1 (#1252)
* Bump numpy from 1.22.4 to 1.23.0 (#1253) (for python_version>=3.8)

Update `pre-commit` hooks.

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Casper Welzel Andersen <casper.w.andersen@sintef.no>